### PR TITLE
Support for .yaml file extension

### DIFF
--- a/lib/views/swagger2.js
+++ b/lib/views/swagger2.js
@@ -4,7 +4,7 @@ import YAML from 'yamljs';
 import jsonfile from 'jsonfile';
 
 const loadFile = function (path) {
-  if (path.match(/\.yml$/)) {
+  if (path.match(/\.ya?ml$/)) {
     return YAML.load(path);
   }
 


### PR DESCRIPTION
You may have `.yaml` for YAML file.
The current filter only supports `.yml`

I wonder if trying to load the file as yaml and acting on failure would be better (?).