### PR TITLE
support missing method description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .DS_Store
 node_modules
 npm-debug.log
-tests/generated
-tests/generated-yaml
-tests/generated-json
+tests/generated*

--- a/lib/views/swagger2.js
+++ b/lib/views/swagger2.js
@@ -51,7 +51,7 @@ export default function getViewForSwagger2 (_swagger) {
       if (authorized_methods.indexOf(method_name.toUpperCase()) === -1) return;
 
       method['operationId'] = method['operationId'] || getOperationId(method_name, path_name);
-      method['descriptionLines'] = wrap(method['description'], { width: 60, indent: '' }).split(/\n/);
+      method['descriptionLines'] = wrap(method['description'] || method['summary'] || '', { width: 60, indent: '' }).split(/\n/);
       _.each(method.parameters, (param, param_name) => {
         if (param.$ref) {
           method.parameters.push(swagger.parameters[param.$ref]);

--- a/tests/missing_description.yml
+++ b/tests/missing_description.yml
@@ -236,3 +236,28 @@ paths:
       security:
         - oauth2:
             - read_users
+definitions:
+  Room:
+    type: object
+    properties:
+      name:
+        type: string
+      private:
+        type: boolean
+        default: false
+    required:
+      - name
+  User:
+    type: object
+    properties:
+      name:
+        type: string
+    required:
+      - name
+  Customer:
+    type: object
+    properties:
+      name:
+        type: string
+    required:
+      - name

--- a/tests/missing_description.yml
+++ b/tests/missing_description.yml
@@ -1,0 +1,238 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Iris
+  description: >
+    Video meetings integrated right inside your app.
+  contact:
+    name: Iris
+    url: 'http://irishd.io'
+    email: fmvilas@gmail.com
+  license:
+      name: Swedish API License Derivative
+      url: 'http://www.apilicens.se/en/dokumentation/resultat/?1=y&2=y&3=y&4=y&5=y&6=y&7=y&8=y&9=y&10=y&11=y&12=y&13=y&'
+host: iris.herokuapp.com
+basePath: /v1
+schemes:
+  - https
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /customers:
+    get:
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of customers
+          required: false
+          type: integer
+          default: 100
+          minimum: 1
+          maximum: 1000
+      responses:
+        '200':
+          description: OK
+      security:
+        - oauth2:
+            - list_customers
+    post:
+      summary: Customers
+      parameters:
+        - name: customer
+          in: body
+          description: The customer JSON you want to post
+          schema:
+            $ref: '#/definitions/Customer'
+          required: true
+      responses:
+        '201':
+          description: OK
+      security:
+        - oauth2:
+            - write_customers
+  '/customers/{id}':
+    get:
+      description: Customers
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          required: true
+      responses:
+        '200':
+          description: OK
+      security:
+        - oauth2:
+            - read_customers
+    put:
+      description: Customers
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          required: true
+      responses:
+        '202':
+          description: OK
+      security:
+        - oauth2:
+            - write_customers
+    delete:
+      description: Customers
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          required: true
+      responses:
+        '202':
+          description: OK
+      security:
+        - oauth2:
+            - write_customers
+  /rooms:
+    get:
+      description: |
+        Gets `Room` objects.
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of rooms
+          required: false
+          type: integer
+          default: 10
+          minimum: 1
+          maximum: 100
+      responses:
+        '200':
+          description: Successful response
+          schema:
+            title: ArrayOfRooms
+            type: array
+            items:
+              $ref: '#/definitions/Room'
+      security:
+        - oauth2:
+            - read_rooms
+    post:
+      description: |
+        Creates new `Room` object.
+      parameters:
+        - name: room
+          in: body
+          description: The room JSON you want to post
+          schema:
+            $ref: '#/definitions/Room'
+          required: true
+      responses:
+        '201':
+          description: Make a new room
+      security:
+        - oauth2:
+            - write_rooms
+  '/rooms/{roomId}':
+    get:
+      description: |
+        Retrieves a room.
+      parameters:
+        - name: roomId
+          in: path
+          type: string
+          description: ID of the room
+          required: true
+      responses:
+        '200':
+          description: Sends the room with room Id
+      security:
+        - oauth2:
+            - read_rooms
+    put:
+      description: |
+        Updates a room.
+      parameters:
+        - name: roomId
+          in: path
+          type: string
+          description: ID of the room
+          required: true
+        - name: room
+          in: body
+          description: The pet JSON you want to post
+          schema:
+            $ref: '#/definitions/Room'
+          required: true
+      responses:
+        '200':
+          description: Updates the pet
+      security:
+        - oauth2:
+            - write_rooms
+    delete:
+      description: Deletes a room
+      parameters:
+        - in: path
+          name: roomId
+          description: Room id to delete
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: Deletes the room
+      security:
+        - oauth2:
+            - write_rooms
+
+  /users:
+    get:
+      description: Users
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of users
+          required: false
+          type: integer
+          default: 100
+          minimum: 1
+          maximum: 1000
+        - name: room
+          in: query
+          description: Filter by room
+          type: integer
+          required: false
+      responses:
+        '200':
+          description: OK
+      security:
+        - oauth2:
+            - read_users
+    post:
+      description: Users
+      parameters:
+        - name: user
+          in: body
+          description: The user JSON you want to post
+          schema:
+            $ref: '#/definitions/User'
+          required: true
+      responses:
+        '201':
+          description: OK
+      security:
+        - oauth2:
+            - write_users
+  '/users/{id}':
+    get:
+      description: Users
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          required: true
+      responses:
+        '200':
+          description: OK
+      security:
+        - oauth2:
+            - read_users

--- a/tests/test.js
+++ b/tests/test.js
@@ -29,3 +29,10 @@ generator.generate({
 }, (err) => {
   if (err) console.log(err.message);
 });
+
+generator.generate({
+  swagger: path.resolve(__dirname, 'missing_description.yml'),
+  target_dir: path.resolve(__dirname, 'generated-with-missing-description')
+}, (err) => {
+  if (err) console.log(err.message);
+});


### PR DESCRIPTION
The description and summary fields are not required as per the [spec](http://swagger.io/specification/#operationObject).

Word-wrap simply returns the input string when (`== null`). 

Related issue: #3 

This breaks the parsing.

NOTE: I did not include the dist/