### PR TITLE
fix handlebars helper 'endsWith' to handle empty strings correctly.

### DIFF
--- a/lib/helpers/handlebars.js
+++ b/lib/helpers/handlebars.js
@@ -25,8 +25,7 @@ Handlebars.registerHelper('equal', (lvalue, rvalue, options) => {
 Handlebars.registerHelper('endsWith', (lvalue, rvalue, options) => {
   if (arguments.length < 3)
     throw new Error('Handlebars Helper equal needs 2 parameters');
-
-  if (lvalue.lastIndexOf(rvalue) !== lvalue.length-1) {
+  if (lvalue.lastIndexOf(rvalue) !== lvalue.length-1 || lvalue.length-1 < 0) {
     return options.inverse(this);
   }
   return options.fn(this);


### PR DESCRIPTION
This fixes #11.