### PR TITLE
Feature: Custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ npm install --save swagger-node-codegen
 
   Options:
 
-    -V, --version             output the version number
-    -o, --output <outputDir>  directory where to put the generated files (defaults to current directory)
-    -h, --help                output usage information
+    -V, --version                  output the version number
+    -o, --output <outputDir>       directory where to put the generated files (defaults to current directory)
+    -t, --templates <templateDir>  directory where templates are located (defaults to internal nodejs templates)
+    -h, --help                     output usage information
 ```
 
 #### Examples
@@ -134,6 +135,7 @@ Generates a code skeleton for an API given an OpenAPI/Swagger file.
 | config | <code>Object</code> | Configuration options |
 | config.swagger | <code>Object</code> \| <code>String</code> | OpenAPI/Swagger JSON or a string pointing to an OpenAPI/Swagger file. |
 | config.target_dir | <code>String</code> | Path to the directory where the files will be generated. |
+| config.templates| <code>String</code> | Path to the directory where custom templates are (optional). |
 
 
 ## Author

--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,7 @@ program
     swaggerFile = path.resolve(swaggerFilePath);
   })
   .option('-o, --output <outputDir>', 'directory where to put the generated files (defaults to current directory)', parseOutput, process.cwd())
+  .option('-t, --templates <templateDir>', 'directory where templates are located (defaults to internal nodejs templates)')
   .parse(process.argv);
 
 if (!swaggerFile) {
@@ -30,7 +31,8 @@ if (!swaggerFile) {
 
 codegen.generate({
   swagger: swaggerFile,
-  target_dir: program.output
+  target_dir: program.output,
+  templates: program.templates
 }).then(() => {
   console.log(green('Done! ✨'));
   console.log(yellow('Check out your shiny new API at ') + magenta(program.output) + yellow('.'));

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -17,119 +17,6 @@ const codegen = module.exports;
 require('./helpers/handlebars');
 
 /**
- * Generates a route file.
- *
- * @private
- * @param  {Object}        config Configuration options
- * @param  {String}        config.target_dir Path to the directory where the files will be generated.
- * @return {Promise}
- */
-const generateRoute = (config, endpoint, endpoint_name) => new Promise((resolve, reject) => {
-  fs.readFile(path.resolve(__dirname, '../templates/src/api/routes/___route.js'), 'utf8', (err, data) => {
-    if (err) return reject(err);
-
-    try {
-      const target_file = path.resolve(config.target_dir, 'src/api/routes/', `${endpoint_name.replace(/[}{]/g, '')}.js`);
-      const template = Handlebars.compile(data.toString());
-      const content = template({
-        service_name: endpoint_name.replace(/[}{]/g, ''),
-        endpoint
-      });
-
-      fs.writeFile(target_file, content, 'utf8', (err) => {
-        if (err) return reject(err);
-        resolve();
-      });
-    } catch (e) {
-      if (e) return reject(e);
-    }
-  });
-});
-
-/**
- * Generates all the routes files.
- *
- * @private
- * @param  {Object}        config Configuration options
- * @param  {Object|String} config.swagger Swagger JSON or a string pointing to a Swagger file.
- * @param  {String}        config.target_dir Path to the directory where the files will be generated.
- * @return {Promise}
- */
-const generateRoutes = config => new Promise((resolve, reject) => {
-  const endpoints = {};
-
-  _.each(config.swagger.paths, (path, path_name) => {
-    const endpoint_name = path.endpointName;
-
-    if (endpoints[endpoint_name] === undefined) {
-      endpoints[endpoint_name] = [];
-    }
-
-    path_name = path_name.replace('}', '').replace('{', ':');
-
-    endpoints[endpoint_name].push({
-      path_name,
-      path,
-      subresource: (path_name.substring(endpoint_name.length+1) || '/').replace('}', '').replace('{', ':')
-    });
-  });
-
-  Promise.all(
-    _.map(endpoints, (endpoint, endpoint_name) => generateRoute(config, endpoint, endpoint_name))
-  ).then(resolve).catch(reject);
-});
-
-/**
- * Generates a service file.
- *
- * @private
- * @param  {Object}        config Configuration options
- * @param  {String}        config.target_dir Path to the directory where the files will be generated.
- * @return {Promise}
- */
-const generateService = (config, service, service_name) => new Promise((resolve, reject) => {
-  fs.readFile(path.resolve(__dirname, '../templates/src/api/services/___service.js'), 'utf8', (err, data) => {
-    if (err) return reject(err);
-
-    const target_file = path.resolve(config.target_dir, 'src/api/services/', `${service_name}.js`);
-    const template = Handlebars.compile(data.toString());
-    const content = template({ service, openbrace: '{', closebrace: '}' });
-
-    fs.writeFile(target_file, content, 'utf8', (err) => {
-      if (err) return reject(err);
-      resolve();
-    });
-  });
-});
-
-/**
- * Generates all the services files.
- *
- * @private
- * @param  {Object}        config Configuration options
- * @param  {Object|String} config.swagger Swagger JSON or a string pointing to a Swagger file.
- * @param  {String}        config.target_dir Path to the directory where the files will be generated.
- * @return {Promise}
- */
-const generateServices = config => new Promise((resolve, reject) => {
-  const services = {};
-
-  _.each(config.swagger.paths, (path, path_name) => {
-    const service_name = path_name === '/' ? 'root' : path_name.split('/')[1].replace(/[}{]/g, '');
-
-    if (services[service_name] === undefined) {
-      services[service_name] = [];
-    }
-
-    services[service_name].push({ path });
-  });
-
-  Promise.all(
-    _.map(services, (service, service_name) => generateService(config, service, service_name))
-  ).then(resolve).catch(reject);
-});
-
-/**
  * Generates a file.
  *
  * @private
@@ -168,17 +55,76 @@ const generateFile = options => new Promise((resolve, reject) => {
 });
 
 /**
+ * Generates a file for every operation.
+ *
+ * @param config
+ * @param operation
+ * @param operation_name
+ * @returns {Promise}
+ */
+const generateOperationFile = (config, operation, operation_name) => new Promise((resolve, reject) => {
+
+  fs.readFile(path.join(config.root, config.file_name), 'utf8', (err, data) => {
+    if (err) return reject(err);
+    const subdir = config.root.replace(`${config.templates_dir}/`,'')
+    const target_file = path.resolve(config.target_dir, subdir, `${operation_name}.js`);
+    const template = Handlebars.compile(data.toString());
+    const content = template({
+      openbrace: '{',
+      closebrace: '}' ,
+      operation_name: operation_name.replace(/[}{]/g, ''),
+      operation
+    });
+
+    fs.writeFile(target_file, content, 'utf8', (err) => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+});
+
+/**
+ * Generates all the files for each operation by iterating over the operations.
+ *
+ * @param   {Object}  config Configuration options
+ * @returns {Promise}
+ */
+const generateOperationFiles = config => new Promise((resolve, reject) => {
+  const files = {};
+  _.each(config.data.swagger.paths, (path, path_name) => {
+    const operation_name = path.endpointName;
+    if (files[operation_name] === undefined) {
+      files[operation_name] = [];
+    }
+
+    path_name = path_name.replace('}', '').replace('{', ':');
+
+    files[operation_name].push({
+      path_name,
+      path,
+      subresource: (path_name.substring(operation_name.length+1) || '/').replace('}', '').replace('{', ':')
+    });
+
+    Promise.all(
+      _.map(files, (operation, operation_name) => generateOperationFile(config, operation, operation_name))
+    ).then(resolve).catch(reject);
+    resolve();
+  });
+});
+
+/**
  * Generates the directory structure.
  *
  * @private
  * @param  {Object}        config Configuration options
  * @param  {Object|String} config.swagger Swagger JSON or a string pointing to a Swagger file.
  * @param  {String}        config.target_dir Path to the directory where the files will be generated.
+ * @param  {String}        config.templates Path to the templates that should be used. Defaults to ./templates
  * @return {Promise}
  */
 const generateDirectoryStructure = config => new Promise((resolve, reject) => {
   const target_dir = config.target_dir;
-  const templates_dir = path.resolve(__dirname, '../templates');
+  const templates_dir = path.resolve(__dirname, config.templates);
 
   xfs.mkdirpSync(target_dir);
 
@@ -192,9 +138,19 @@ const generateDirectoryStructure = config => new Promise((resolve, reject) => {
     walker.on('file', async (root, stats, next) => {
       try {
         if (stats.name.substr(0,3) === '___') {
+          // this file should be handled for each in swagger.paths
+          await generateOperationFiles({
+            root,
+            templates_dir,
+            target_dir,
+            data: config,
+            file_name: stats.name
+          });
           const template_path = path.relative(templates_dir, path.resolve(root, stats.name));
           fs.unlink(path.resolve(target_dir, template_path), next);
+          next();
         } else {
+          // this file should only exist once.
           await generateFile({
             root,
             templates_dir,
@@ -214,13 +170,7 @@ const generateDirectoryStructure = config => new Promise((resolve, reject) => {
     });
 
     walker.on('end', async () => {
-      try {
-        await generateRoutes(config);
-        await generateServices(config);
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
+      resolve();
     });
   });
 });
@@ -248,7 +198,8 @@ codegen.generate = config => new Promise((resolve, reject) => {
       package: {
         name: _.kebabCase(_.result(config, 'swagger.info.title', random_name))
       },
-      target_dir: path.resolve(os.tmpdir(), 'swagger-node-generated-code')
+      target_dir: path.resolve(os.tmpdir(), 'swagger-node-generated-code'),
+      templates: '../templates'
     });
 
     generateDirectoryStructure(config).then(resolve).catch(reject);

--- a/templates/src/api/routes/___route.js
+++ b/templates/src/api/routes/___route.js
@@ -1,9 +1,9 @@
 const express = require('express');
-const {{camelCase service_name}} = require('../services/{{service_name}}');
+const {{camelCase operation_name}} = require('../services/{{operation_name}}');
 
 const router = new express.Router();
 
-{{#each endpoint}}
+{{#each operation}}
   {{#each this.path}}
     {{#validMethod @key}}
 /**
@@ -29,7 +29,7 @@ router.{{@key}}('{{../../subresource}}', async (req, res, next) => {
   };
 
   try {
-    const result = await {{camelCase ../../../service_name}}.{{../operationId}}(options);
+    const result = await {{camelCase ../../../operation_name}}.{{../operationId}}(options);
     {{#ifNoSuccessResponses ../responses}}
     res.status(200).send(result.data);
     {{else}}

--- a/templates/src/api/services/___service.js
+++ b/templates/src/api/services/___service.js
@@ -1,4 +1,4 @@
-{{#each service}}
+{{#each operation}}
   {{#each this.path}}
     {{#validMethod @key}}
 /**


### PR DESCRIPTION
This PR changes two things that belong closely together:
1. It adds an cli parameter 'templates' which allows to specify an alternative location for handlebars templates.
2. It merges the concept of 'Services' and 'Routes' inside the generator into 'Operation' to make it more abstract. This allows to have any kind of 'Operation'-specific file in the templates, not only routes and services. Exactly as route- and service-specific files before, operation-specific files must be named with a leading triple underscore.

Both things together allows us to use the generator not only for a nodejs/express based webserver, but for every kind of OpenAPI based server/client. (e.g. in our case we want an Angular Client Library).