### PR TITLE
Replace only picks first instance of string

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -97,12 +97,12 @@ const generateOperationFiles = config => new Promise((resolve, reject) => {
       files[operation_name] = [];
     }
 
-    path_name = path_name.replace('}', '').replace('{', ':');
+    path_name = path_name.replace(/}/g, '').replace(/{/g, ':');
 
     files[operation_name].push({
       path_name,
       path,
-      subresource: (path_name.substring(operation_name.length+1) || '/').replace('}', '').replace('{', ':')
+      subresource: (path_name.substring(operation_name.length+1) || '/').replace(/}/g, '').replace(/{/g, ':')
     });
 
     Promise.all(


### PR DESCRIPTION
Unless you use a regex! This meant that paths with lots of parameters were only seeing the first two instances being replaced seeing things like:

```/:username/projects/:project/analyses/{lastAnalysisNumber}/differential```

