### PR TITLE
Quote js identifiers if they include special characters

### DIFF
--- a/lib/helpers/handlebars.js
+++ b/lib/helpers/handlebars.js
@@ -128,3 +128,10 @@ Handlebars.registerHelper('camelCase', (str) => {
 Handlebars.registerHelper('inline', (str) => {
   return str ? str.replace(/\n/g, '') : '';
 });
+
+/**
+ * Quotes a JS identifier, if necessary.
+ */
+Handlebars.registerHelper('quote', (str) => {
+  return /[$&@-]/.test(str) ? `'${str}'` : str
+});

--- a/templates/express-server/src/api/routes/___.js
+++ b/templates/express-server/src/api/routes/___.js
@@ -15,14 +15,14 @@ router.{{@key}}('{{../../subresource}}', async (req, res, next) => {
   const options = {
     {{#each ../parameters}}
       {{#equal this.in "query"}}
-    {{../name}}: req.query.{{../name}}{{#unless @last}},{{/unless}}
+    {{{quote ../name}}}: req.query['{{../name}}']{{#unless @last}},{{/unless}}
       {{/equal}}
       {{#equal this.in "path"}}
-    {{../name}}: req.params.{{../name}}{{#unless @last}},{{/unless}}
+    {{{quote ../name}}}: req.params['{{../name}}']{{#unless @last}},{{/unless}}
       {{/equal}}
       {{#match @../key "(post|put)"}}
         {{#equal ../in "body"}}
-    {{../name}}: req.body.{{../name}}{{#unless @last}},{{/unless}}
+    {{{quote ../name}}}: req.body['{{../name}}']{{#unless @last}},{{/unless}}
         {{/equal}}
       {{/match}}
     {{/each}}


### PR DESCRIPTION
Fixes #35

The regex is not an exhaustive list -- just common stuff.  I'm not sure if anyone is going to use `|` in a query parameter name, but if so it's easy enough to fix.