### PR TITLE
Upgraded lodash, fix npm audit failures

### DIFF
--- a/lib/swagger2.js
+++ b/lib/swagger2.js
@@ -69,7 +69,7 @@ const swagger2 = async swagger => {
     });
   });
 
-  swagger.endpoints = _.unique(_.pluck(swagger.paths, 'endpointName'));
+  swagger.endpoints = _.uniq(_.map(swagger.paths, 'endpointName'));
 
   return swagger;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,9 @@
       }
     },
     "handlebars": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -105,9 +105,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "minimist": {
       "version": "0.0.10",
@@ -188,9 +188,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "uglify-js": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
-      "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.6.tgz",
+      "integrity": "sha512-YDKRX8F0Y+Jr7LhoVk0n4G7ltR3Y7qFAj+DtVBthlOgCcIj1hyMigCfousVfn9HKmvJ+qiFlLDwaHx44/e5ZKw==",
       "optional": true,
       "requires": {
         "commander": "~2.20.0",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   "dependencies": {
     "commander": "^2.12.2",
     "fs.extra": "1.3.2",
-    "handlebars": "^4.1.1",
+    "handlebars": "^4.1.2",
     "js-yaml": "^3.13.1",
     "json-schema-ref-parser": "^4.0.4",
-    "lodash": "3.10.1",
+    "lodash": "^4.17.11",
     "project-name-generator": "^2.1.6",
     "word-wrap": "1.1.0"
   }


### PR DESCRIPTION
There are some security vulnerabilities reported by `npm audit` for the versions of lodash and handlebars that are specified currently. This PR fixes both.

The code changes in `lib/swagger2.js` are required for the upgrade from lodash 3.x to 4.x. I used the [`lodash-migrate`](https://www.npmjs.com/package/lodash-migrate) tool to help with this.
